### PR TITLE
Add janeway_version management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ A janeway plugin that contains management commands used by cdl staff
 * `import_earth`
 * `import_eer`
 * `import_plos2EA`
+* `janeway_version`
 * `missing_workflowlogs_report`
 * `move_preprints <active-user> <proxy-user>` - Merges metadata associated with a proxy user into a specified user account.  This account may be actived or not but it should be one that could be activated in the future.

--- a/management/commands/janeway_version.py
+++ b/management/commands/janeway_version.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+
+import git
+from utils.logic import get_janeway_version
+
+class Command(BaseCommand):
+    """
+    Prints the current version of Janeway, the git remote, the current git branch, commit hash,
+    and last log line
+    """
+
+    help = "Prints version information for this Janeway installation. Requires gitpython module: pip install gitpython"
+
+    def handle(self, *args, **options):
+        """Prints Janeway version information
+
+        :param args: None
+        :param options: dict
+        :return: None
+        """
+    version = get_janeway_version()
+    repo = git.Repo(search_parent_directories=True)
+    remote_url = repo.remotes.origin.url
+    branch = repo.head.ref
+    commit_hash = repo.head.object.hexsha
+    last_log_line = repo.head.log()[-1]
+
+    print("Janeway Version:", version)
+    print("Remote URL:", remote_url)
+    print("Current branch:", branch)
+    print("Commit hash:", commit_hash)
+    print("Last log line:", last_log_line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+gitpython


### PR DESCRIPTION
- janeway_version management command is a simple tool to help us keep track of exactly what is running where
- command outputs the current Janeway version, the github remote URL, the current branch, the commit hash, and the last git log message