### PR TITLE
Pubd 882 delete journal command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 __pycache__/

--- a/management/commands/delete_journal.py
+++ b/management/commands/delete_journal.py
@@ -21,9 +21,15 @@ class Command(BaseCommand):
         parser.add_argument(
             "journal_code", help="`code` of the journal to to delete", type=str
         )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help="Print the output but don't delete",
+        )
 
     def handle(self, *args, **options):
         journal_code = options.get("journal_code")
+        delete = not options["dry_run"]
 
         j = Journal.objects.get(code=journal_code)
 
@@ -43,20 +49,25 @@ class Command(BaseCommand):
                     path = os.path.join(settings.BASE_DIR, 'files', 'articles', str(a.pk), str(h.uuid_filename))
                     if os.path.exists(path):
                         print(f'\t\t\tFound path to delete: {path}')
-                        os.unlink(path)
+                        if delete:
+                            os.unlink(path)
                     else:
                         path = os.path.join(aux_dir , str(h.uuid_filename))
                         if os.path.exists(path):
                             print(f'\t\t\tFound path to delete: {path}')
-                            os.unlink(path)
+                            if delete:
+                                os.unlink(path)
                         else:
                             print("\t\t\tNo file history found")
                 print(f'\tDelete file object: {f.pk}')
-                f.delete()
+                if delete:
+                    f.delete()
             if os.path.exists(aux_dir):
                 print(f'\tdelete aux dir: {aux_dir}')
-                os.unlink(aux_dir)
+                if delete:
+                    os.unlink(aux_dir)
             else:
                 print(f'No aux dir {aux_dir} found.')
-        j.delete()
+        if delete:
+            j.delete()
         print(f'Deleting journal {j.name}')

--- a/management/commands/delete_journal.py
+++ b/management/commands/delete_journal.py
@@ -59,6 +59,9 @@ class Command(BaseCommand):
                                 os.unlink(path)
                         else:
                             print("\t\t\tNo file history found")
+                    print(f'\t\tDelete file history object: {h.pk}')
+                    if delete:
+                        h.delete()
                 print(f'\tDelete file object: {f.pk}')
                 if delete:
                     f.delete()

--- a/management/commands/delete_journal.py
+++ b/management/commands/delete_journal.py
@@ -1,0 +1,50 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from journal.models import Journal
+from core.models import File
+import os
+from django.conf import settings
+
+def boolean_input(question, default=None):
+    result = input("%s " % question)
+    if not result and default is not None:
+        return default
+    while len(result) < 1 or result[0].lower() not in "yn":
+        result = input("Please answer yes or no: ")
+    return result[0].lower() == "y"
+
+class Command(BaseCommand):
+    """Fully deletes a journal including all associated files and objects"""
+    help = "Fully deletes a journal including all associated files and objects"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "journal_code", help="`code` of the journal to add arks", type=str
+        )
+
+    def handle(self, *args, **options):
+        journal_code = options.get("journal_code")
+
+        j = Journal.objects.get(code=journal_code)
+
+        prompt = f'You are deleting {j} and all associated files.'
+        self.stdout.write(self.style.NOTICE(prompt))
+
+        if not boolean_input("Are you sure? (yes/no)"):
+            raise CommandError("delete journal aborted")
+
+        for a in j.article_set.all():
+            aux_dir = os.path.join(settings.BASE_DIR, 'files', f'{a.pk - {}}', str(a.pk))
+            for f in File.objects.filter(article_id=a.pk):
+                for h in f.history.all():
+                    path = os.path.join(settings.BASE_DIR, 'files', 'articles', str(a.pk), str(h.uuid_filename))
+                    if os.path.exists(path):
+                        os.unlink(path)
+                    else:
+                        path = os.path.join(aux_dir , str(h.uuid_filename))
+                        if os.path.exists(path):
+                            os.unlink(path)
+                f.delete()
+            if os.path.exists(aux_dir):
+                os.unlink(aux_dir)
+        j.delete()


### PR DESCRIPTION
when you delete a journal in janeway it leaves around a  bunch of files, file objects and file history objects.  This command deletes all of these before deleting the journal so we don't end up with tons of orphans.  this is most useful with the migration testing I've been doing where I have to make tweaks and redo the migration from a clean slate.