### PR TITLE
just add the licenses to all the relevant issues

### DIFF
--- a/management/commands/add_licenses_by_issue.py
+++ b/management/commands/add_licenses_by_issue.py
@@ -38,14 +38,13 @@ class Command(BaseCommand):
                 i_set = Issue.objects.filter(journal=j, volume=i["volume"], issue=i["issue"]).exclude(articles=None)
                 if not i_set.exists():
                     print(f'ERROR issue not found: {i["volume"]} {i["issue"]}')
-                elif i_set.count() > 1:
-                    print(f'ERROR duplicate issues found: {i["volume"]} {i["issue"]}')
                 else:
-                    print(f'Found issue: {i["volume"]} {i["issue"]}')
-                    issue = i_set[0]
-                    for a in issue.articles.all():
-                        if a.license:
-                            print(f'\tArticle already has license {a.pk}')
-                        else:
+                    if i_set.count() > 1:
+                        print(f'Found multiple issues ({i_set.count()}): {i["volume"]} {i["issue"]}')
+                    else:
+                        print(f'Found issue: {i["volume"]} {i["issue"]}')
+
+                    for issue in i_set.all():
+                        for a in issue.articles.all():
                             a.license = license
                             a.save()

--- a/test_files/test_cc.tsv
+++ b/test_files/test_cc.tsv
@@ -1,0 +1,2 @@
+volume	issue	rights
+0	0	https://creativecommons.org/licenses/by-nc/4.0/

--- a/tests.py
+++ b/tests.py
@@ -3,10 +3,11 @@ from django.test import TestCase
 from utils.testing import helpers
 
 from submission.models import Article
-from journal.models import Journal
+from journal.models import Journal, Issue
 
 from io import StringIO
 from django.core.management import call_command
+import os
 
 class TestDeleteJournals(TestCase):
 
@@ -44,3 +45,43 @@ class TestDeleteJournals(TestCase):
         self.assertEqual(Journal.objects.count(), 2)
         self.assertEqual(Article.objects.filter(journal=None).count(), 0)
         self.assertEqual(Article.objects.count(), 1)
+
+class TestAddLicenses(TestCase):
+
+    def setUp(self):
+        self.journal, _ = helpers.create_journals()
+        self.article1 = helpers.create_article(self.journal)
+        self.article2 = helpers.create_article(self.journal)
+        self.issue1 = helpers.create_issue(self.journal, articles=[self.article1])
+        self.issue2 = self.create_duplicate_issue(self.issue1)
+        self.issue2.articles.add(self.article2)
+        self.issue2.save()
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "add_licenses_by_issue",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def create_duplicate_issue(self, issue):
+        issue2 = Issue.objects.create(journal=issue.journal,
+                                      issue=issue.issue,
+                                      volume=issue.volume,
+                                      issue_title='Duplicate Issue',
+                                      issue_type=issue.issue_type,
+                                      date=issue.date)
+        return issue2
+
+    def get_file_path(self, filename):
+        return f'{os.path.dirname(__file__)}/test_files/{filename}'
+
+    def test_duplicate_issues(self):
+        out = self.call_command(self.journal.code, self.get_file_path("test_cc.tsv"))
+        self.assertEqual(Article.objects.get(pk=self.article1.pk).license.short_name, "CC BY-NC 4.0")
+        self.assertEqual(Article.objects.get(pk=self.article2.pk).license.short_name, "CC BY-NC 4.0")
+


### PR DESCRIPTION
- Just add cc licenses to articles in all issues that match jschol export

I had written this assuming that there shouldn't be duplicate issues that both have articles.  This isn't true for westjem and I don't really see any issue with just applying the cc license to everything.  One of those issues probably should never be published but it's better for everything to have a cc license and service team can figure out what to do with the duplicate issues later.