### PR TITLE
Pubd 1139 report missing stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A janeway plugin that contains management commands used by cdl staff
 * `janeway_version`
 * `missing_workflowlogs_report`
 * `move_preprints <active-user> <proxy-user>` - Merges metadata associated with a proxy user into a specified user account.  This account may be actived or not but it should be one that could be activated in the future.
+* `no_arks <journal-code>` - Reports published articles in a given journal that don't have an associated eScholarship ark
+* `no_correspondence_author <journal-code>` - Reports articles in a given journal that don't have a correspondence author
 
 ## Tests
 

--- a/management/commands/no_arks.py
+++ b/management/commands/no_arks.py
@@ -22,9 +22,9 @@ class Command(BaseCommand):
             raise CommandError(f"No journal code = {code} found")
 
         ids = EscholArticle.objects.filter(article__journal__code=code).values_list('article__pk', flat=True)
-        articles = Article.objects.filter(journal__code="uccllt_l2", stage="Published").exclude(pk__in=ids)
+        articles = Article.objects.filter(journal__code=code, stage="Published").exclude(pk__in=ids)
         if articles.count() == 0:
-            print(f"There are no articles in {code} without an escholarship ark assigned")
+            print(f"There are no published articles in {code} without an escholarship ark assigned")
         else:
             for a in articles:
                 print(f'{a.stage}\t{a.pk}\t{a.url}')

--- a/management/commands/no_arks.py
+++ b/management/commands/no_arks.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from submission.models import Article
+from plugins.eschol.models import EscholArticle
+from journal.models import Journal
+
+
+class Command(BaseCommand):
+    """Reports published articles that don't have an ark from a given journal"""
+    help = "Reports published articles that don't have an ark from a given journal"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "journal_code", help="`code` of the journal to report on", type=str
+        )
+
+    def handle(self, *args, **options):
+        code = options.get("journal_code")
+
+        if not Journal.objects.filter(code=code).exists():
+            raise CommandError(f"No journal code = {code} found")
+
+        ids = EscholArticle.objects.filter(article__journal__code=code).values_list('article__pk', flat=True)
+        articles = Article.objects.filter(journal__code="uccllt_l2", stage="Published").exclude(pk__in=ids)
+        if articles.count() == 0:
+            print(f"There are no articles in {code} without an escholarship ark assigned")
+        else:
+            for a in articles:
+                print(f'{a.stage}\t{a.pk}\t{a.url}')

--- a/management/commands/no_correspondence_author.py
+++ b/management/commands/no_correspondence_author.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from submission.models import Article
+from journal.models import Journal
+
+class Command(BaseCommand):
+    """Reports the articles that don't have correspondence authors from a given journal"""
+    help = "Reports the articles that don't have correspondence authors from a given journal"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "journal_code", help="`code` of the journal to report on", type=str
+        )
+
+    def handle(self, *args, **options):
+        code = options.get("journal_code")
+
+        if not Journal.objects.filter(code=code).exists():
+            raise CommandError(f"No journal code = {code} found")
+
+        articles = Article.objects.filter(journal__code=code, correspondence_author=None)
+        if articles.count() == 0:
+            print(f"There are no articles in {code} without a correspondence author")
+        else:
+            for a in articles:
+                print(f'{a.stage}\t{a.pk}\t{a.title}\t{a.url}')


### PR DESCRIPTION
Reporting missing stuff for migration checks
- Command to report published articles that don't have eScholarship arks
- Command to report articles without correspondence authors