### PR TITLE
truncate journal codes

### DIFF
--- a/management/commands/add_licenses_by_issue.py
+++ b/management/commands/add_licenses_by_issue.py
@@ -1,6 +1,6 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
-import csv
+import csv, os
 
 # You can create the expected input file with the following query to the jschol DB
 # SELECT volume, issue, attrs->>'$.rights' as rights FROM issues WHERE unit_id = '';
@@ -26,27 +26,41 @@ class Command(BaseCommand):
         journal_code = options.get("journal_code")[:24]
         import_file = options.get("import_file")
 
+        if not Journal.objects.filter(code=journal_code).exists():
+            raise CommandError(f'Journal does not exist {journal_code}')
+
         j = Journal.objects.get(code=journal_code)
 
+        if not os.path.exists(import_file):
+            raise CommandError(f'File {import_file} not found.')
+
+        cc_licenses = 0
+        issue_count = 0
+        article_count = 0
+        errors = 0
         with open(import_file, 'r') as csvfile:
             reader = csv.DictReader(csvfile, delimiter="\t")
             for i in reader:
-                license, created = Licence.objects.get_or_create(journal=j, url=i["rights"].rstrip("/"))
-                if created:
-                    print(f'Added license: {j} {i["rights"]}')
-                else:
-                    print(f'Found license: {j} {i["rights"]}')
-                
-                i_set = Issue.objects.filter(journal=j, volume=i["volume"], issue=i["issue"]).exclude(articles=None)
-                if not i_set.exists():
-                    print(f'ERROR issue not found: {i["volume"]} {i["issue"]}')
-                else:
-                    if i_set.count() > 1:
-                        print(f'Found multiple issues ({i_set.count()}): {i["volume"]} {i["issue"]}')
+                if i["rights"] != "NULL":
+                    cc_licenses += 1
+                    license, created = Licence.objects.get_or_create(journal=j, url=i["rights"].rstrip("/"))
+                    i_set = Issue.objects.filter(journal=j, volume=i["volume"], issue=i["issue"]).exclude(articles=None)
+                    if not i_set.exists():
+                        self.stdout.write(self.style.ERROR(f'ERROR issue not found: {i["volume"]} {i["issue"]}'))
+                        errors += 1
                     else:
-                        print(f'Found issue: {i["volume"]} {i["issue"]}')
+                        issue_count += i_set.count()
+                        for issue in i_set.all():
+                            article_count += issue.articles.count()
+                            for a in issue.articles.all():
+                                a.license = license
+                                a.save()
 
-                    for issue in i_set.all():
-                        for a in issue.articles.all():
-                            a.license = license
-                            a.save()
+        if cc_licenses == 0:
+            self.stdout.write(self.style.NOTICE(f"No CC licenses found for {journal_code}"))
+        else:
+            if issue_count > 0:
+                self.stdout.write(self.style.SUCCESS(f'✅ CC licenses added to {article_count} articles in {issue_count} issues.'))
+                self.stdout.write(self.style.NOTICE("Note: if duplicate issues were found licenses were added to both"))
+            if errors > 0:
+                self.stdout.write(self.style.ERROR(f"{errors} issues not found."))

--- a/management/commands/add_licenses_by_issue.py
+++ b/management/commands/add_licenses_by_issue.py
@@ -21,7 +21,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        journal_code = options.get("journal_code")
+        # janeway journal codes are limited to 24 chars
+        # truncate it if the user doesn't
+        journal_code = options.get("journal_code")[:24]
         import_file = options.get("import_file")
 
         j = Journal.objects.get(code=journal_code)

--- a/management/commands/no_correspondence_author.py
+++ b/management/commands/no_correspondence_author.py
@@ -14,7 +14,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        code = options.get("journal_code")
+        # janeway journal codes are limited to 24 chars
+        # truncate it if the user doesn't
+        code = options.get("journal_code")[:24]
 
         if not Journal.objects.filter(code=code).exists():
             raise CommandError(f"No journal code = {code} found")

--- a/test_files/test_null_cc.tsv
+++ b/test_files/test_null_cc.tsv
@@ -1,0 +1,2 @@
+volume	issue	rights
+0	0	NULL

--- a/tests.py
+++ b/tests.py
@@ -146,6 +146,11 @@ class TestAddLicenses(TestCase):
         self.assertEqual(Article.objects.get(pk=self.article1.pk).license.short_name, "CC BY-NC 4.0")
         self.assertEqual(Article.objects.get(pk=self.article2.pk).license.short_name, "CC BY-NC 4.0")
 
+    def test_null_license(self):
+        out = self.call_command(self.journal.code, self.get_file_path("test_null_cc.tsv"))
+        self.assertIsNone(Article.objects.get(pk=self.article1.pk).license)
+        self.assertIsNone(Article.objects.get(pk=self.article2.pk).license)
+
 class TestAddPreprintAuthors(TestCase):
 
     def create_account(self, email, fname, mname, lname, institution):


### PR DESCRIPTION
- truncate journal codes for all steps in the import process. This shouldn't cause a problem if the user uses the code from janeway but will prevent an error if they use the ojs code.
- Add a few more checks so we get nice error message if the inputs aren't correct
- Clean up the output so it's more clear if we were successful or not.