### PR TITLE
Add command to set default preferred timezone

### DIFF
--- a/management/commands/set_default_preferred_timezone.py
+++ b/management/commands/set_default_preferred_timezone.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         try:
             num_updated = (Account.objects
                 .filter(preferred_timezone__isnull=True)
-                .update("preferred_timezone","US/Pacific")
+                .update(preferred_timezone="US/Pacific")
             )
         except Exception as e:
             raise CommandError('Unable to set preferred_timezones for new users due to error\n %s' % e)

--- a/management/commands/set_default_preferred_timezone.py
+++ b/management/commands/set_default_preferred_timezone.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand, CommandError
+from core.models import Account
+
+
+class Command(BaseCommand):
+    """Find users with no preferred_timezone and set it to US/Pacific"""
+    help = "Find users with no preferred_timezone and set it to US/Pacific"
+
+
+
+    def handle(self, *args, **options):
+
+        try:
+            num_updated = (Account.objects
+                .filter(preferred_timezone__isnull=True)
+                .update("preferred_timezone","US/Pacific")
+            )
+        except Exception as e:
+            raise CommandError('Unable to set preferred_timezones for new users due to error\n %s' % e)
+        
+        print(f"Preferred Timezone updated to US/Pacific for {num_updated} users.")


### PR DESCRIPTION
Looks for all users with a timezone of null and updates their timezone to the CDL preferred US/Pacific timezone. Users with any existing preferred timezone value will no be impacted